### PR TITLE
feat: make userimage rounded on ogp image

### DIFF
--- a/src/growi-ogp-drawer.js
+++ b/src/growi-ogp-drawer.js
@@ -129,10 +129,25 @@ exports.GrowiOgpDrawer = class GrowiOgpDrawer {
         image.src = Buffer.from(this.bufferedUserImage);
 
         const userNameWidth = this.context.measureText(this.userName).width;
-        
-        // todo: adjust position and image will be rounded
-        this.context.drawImage(image, this.centerX - (userNameWidth / 2) - userNameAndImageMargin, this.imageHeight - marginBottom - (userImageSize/2) , userImageSize, userImageSize);
+
         this.context.fillText(this.userName, this.centerX, this.imageHeight - marginBottom);
+        
+        //
+        // todo: adjust all positions based on entire image
+        // 
+
+        // rounded image
+        this.context.beginPath();
+        this.context.arc(
+            this.centerX - (userNameWidth / 2) - userNameAndImageMargin + userImageSize/2,
+            this.imageHeight - marginBottom - (userImageSize/2) + userImageSize/2,
+            20, // radius
+            0,
+            Math.PI*2,
+            false,
+        );
+        this.context.clip();
+        this.context.drawImage(image, this.centerX - (userNameWidth / 2) - userNameAndImageMargin, this.imageHeight - marginBottom - (userImageSize/2) , userImageSize, userImageSize);
     }
 
     drawWrapText(text, maxWidth, lineHeight, maxLineNumber) {

--- a/src/growi-ogp-drawer.js
+++ b/src/growi-ogp-drawer.js
@@ -106,9 +106,9 @@ exports.GrowiOgpDrawer = class GrowiOgpDrawer {
   }
 
   /**
-     *
-     * @param {string} fontOptions canvas font selecter like 'bold 70px sans-serif'
-     */
+   *
+   * @param {string} fontOptions canvas font selecter like 'bold 70px sans-serif'
+   */
   drawTitle(fontOptions, textColor, textAlign, textBaseline, MaxWidth) {
 
     const titleFontOptions = fontOptions || this.titleFontOptions;
@@ -122,9 +122,9 @@ exports.GrowiOgpDrawer = class GrowiOgpDrawer {
   }
 
   /**
-     *
-     * @param {string} fontOptions canvas font selecter like 'bold 70px sans-serif'
-     */
+   *
+   * @param {string} fontOptions canvas font selecter like 'bold 70px sans-serif'
+  */
   drawUserNameAndImage(fontOptions, textColor, textAlign, textBaseline, userNameAndImageMargin = 55, marginBottom = 50, userImageSize = 40) {
 
     const userNameFontOptions = fontOptions || this.userNameFontOptions;
@@ -160,7 +160,6 @@ exports.GrowiOgpDrawer = class GrowiOgpDrawer {
       userImageSize,
     );
   }
-
 
   drawWrapText(text, maxWidth, lineHeight, maxLineNumber) {
 


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/86299

## 行ったこと

- growi 側から送信される画像を丸くして OGP イメージ上に表示しました
- 後続タスクで、全体的なポジションの微調整とコードを整えます

## 画像

![ogp_rounded_image](https://user-images.githubusercontent.com/83065937/150287542-4d0a9a94-c755-455e-995a-4baa04b1ebf1.PNG)

