### PR TITLE
imrpv: change named volume of node_modules in dev docker-compose

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ..:/workspace/growi-ogp:delegated
-      - node_modules:/workspace/growi-ogp/node_modules
+      - node_modules:/workspace/growi-ogp/src/node_modules
     ports:
       - 8088:8088
     tty: true


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/86649

## 行ったこと

- devcontainer docker-compose の node_modules の named volume ディレクトリが間違っていたので修正しました