### PR TITLE
use multi stage build on production Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,3 @@
-# ---- Base Node ----
-FROM node:16-slim AS base
-
-# librsvg2-dev must be required for node canvas font
-RUN apt-get update -y && apt-get install -y librsvg2-dev fonts-noto-cjk
-
 # ---- Dependencies ----
 FROM node:16-slim as dependencies
 
@@ -11,7 +5,14 @@ COPY src/package*.json .
 RUN npm install --only=production
 
 # ---- Start ----
-FROM base AS start
+FROM node:16-slim
+
+# librsvg2-dev must be required for node canvas font
+RUN apt-get update -y \
+    && apt-get install -y librsvg2-dev fonts-noto-cjk \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /ogp/src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,22 @@
-FROM node:16-slim
+# ---- Base Node ----
+FROM node:16-slim AS base
 
-RUN apt-get update -y && apt-get install -y python3 build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fonts-noto-cjk
+# librsvg2-dev must be required for node canvas font
+RUN apt-get update -y && apt-get install -y librsvg2-dev fonts-noto-cjk
 
-COPY src/ /ogp/src/
-COPY resources/ /ogp/resources/
+# ---- Dependencies ----
+FROM node:16-slim as dependencies
+
+COPY src/package*.json .
+RUN npm install --only=production
+
+# ---- Start ----
+FROM base AS start
 
 WORKDIR /ogp/src
 
-RUN ["/bin/bash", "-c", "npm install"]
+COPY --from=dependencies ./node_modules ./node_modules
+COPY src/ /ogp/src/
+COPY resources/ /ogp/resources/
 
 ENTRYPOINT node index.js


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/89008

## FB 対応

- Dockerfile に apt キャッシュ削除を追加しました


## 行ったこと

- Dockerfile からビルドする際に、マルチステージビルドを使用
    - マルチステージビルドによるイメージ軽量化は微量(元々コンパイルなどはしていないため)
    - マルチステージビルドしない場合:  706 MB
    - マルチステージビルドした場合:  681 MB
- ベースイメージから不要なパッケージの削除

## 備考

- ローカルで Dockerfile から build して、本体とつないで動作確認は一応完了済み